### PR TITLE
Add multithreaded BLAST, fix same-filename collision, configurable GC window, auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,65 @@
+name: Auto Release on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  bump-and-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get current version
+        id: current_version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $VERSION"
+
+      - name: Bump patch version
+        id: new_version
+        run: |
+          CURRENT=${{ steps.current_version.outputs.version }}
+          # Split on dots and bump patch
+          MAJOR=$(echo $CURRENT | cut -d. -f1)
+          MINOR=$(echo $CURRENT | cut -d. -f2)
+          PATCH=$(echo $CURRENT | cut -d. -f3)
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      - name: Set new version in pom.xml
+        run: mvn versions:set -DnewVersion=${{ steps.new_version.outputs.version }} -DgenerateBackupPoms=false -q
+
+      - name: Commit version bump
+        run: |
+          git add pom.xml
+          git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }} [skip ci]"
+
+      - name: Create and push tag
+        run: |
+          TAG="v${{ steps.new_version.outputs.version }}"
+          git tag "$TAG"
+          git push origin master
+          git push origin "$TAG"
+          echo "Created tag $TAG — release workflow will build packages"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bump-and-release:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -49,16 +49,18 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
-      - name: Set new version in pom.xml
+      - name: Set new version in pom.xml and pixi.toml
         env:
           NEW_VERSION: ${{ steps.new_version.outputs.version }}
-        run: mvn versions:set -DnewVersion="$NEW_VERSION" -DgenerateBackupPoms=false -q
+        run: |
+          mvn versions:set -DnewVersion="$NEW_VERSION" -DgenerateBackupPoms=false -q
+          sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pixi.toml
 
       - name: Commit version bump
         env:
           NEW_VERSION: ${{ steps.new_version.outputs.version }}
         run: |
-          git add pom.xml
+          git add pom.xml pixi.toml
           git commit -m "chore: bump version to ${NEW_VERSION} [no ci]"
 
       - name: Create and push tag

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -37,28 +37,35 @@ jobs:
 
       - name: Bump patch version
         id: new_version
+        env:
+          CURRENT: ${{ steps.current_version.outputs.version }}
         run: |
-          CURRENT=${{ steps.current_version.outputs.version }}
           # Split on dots and bump patch
-          MAJOR=$(echo $CURRENT | cut -d. -f1)
-          MINOR=$(echo $CURRENT | cut -d. -f2)
-          PATCH=$(echo $CURRENT | cut -d. -f3)
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
           NEW_PATCH=$((PATCH + 1))
           NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
       - name: Set new version in pom.xml
-        run: mvn versions:set -DnewVersion=${{ steps.new_version.outputs.version }} -DgenerateBackupPoms=false -q
+        env:
+          NEW_VERSION: ${{ steps.new_version.outputs.version }}
+        run: mvn versions:set -DnewVersion="$NEW_VERSION" -DgenerateBackupPoms=false -q
 
       - name: Commit version bump
+        env:
+          NEW_VERSION: ${{ steps.new_version.outputs.version }}
         run: |
           git add pom.xml
-          git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }} [skip ci]"
+          git commit -m "chore: bump version to ${NEW_VERSION} [no ci]"
 
       - name: Create and push tag
+        env:
+          NEW_VERSION: ${{ steps.new_version.outputs.version }}
         run: |
-          TAG="v${{ steps.new_version.outputs.version }}"
+          TAG="v${NEW_VERSION}"
           git tag "$TAG"
           git push origin master
           git push origin "$TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           pixi-version: latest
 
       - name: Install BLAST+ via pixi
-        run: pixi install --frozen-lockfile false
+        run: pixi install
 
       - name: Install local cgview dependency
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Install BLAST+ via pixi
+        run: pixi install
+
       - name: Install local cgview dependency
         run: >
           mvn install:install-file
@@ -22,5 +33,11 @@ jobs:
           -Dversion=2.0.3-SNAPSHOT
           -Dpackaging=jar
           -q
+
       - run: mvn clean package -q
-      - run: mvn test
+
+      - name: Run unit tests
+        run: mvn test
+
+      - name: Run E2E tests (requires BLAST+)
+        run: pixi run mvn test -Dtest.excludedGroups= -Dgroups=e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,9 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: latest
-          cache: true
 
       - name: Install BLAST+ via pixi
-        run: pixi install
+        run: pixi install --frozen-lockfile false
 
       - name: Install local cgview dependency
         run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           -Dpackaging=jar
           -q
       - run: mvn clean package -q
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: BRIG-jar
           path: |
@@ -67,7 +67,7 @@ jobs:
             --java-options "-Xmx1500M" \
             --icon src/main/resources/brig.icns \
             --dest dist/
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: BRIG-macos
           path: dist/*.dmg
@@ -113,7 +113,7 @@ jobs:
             --win-menu \
             --win-shortcut \
             --dest dist/
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: BRIG-windows
           path: dist/*.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: BRIG-jar
           path: target/
@@ -81,7 +81,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: BRIG-jar
           path: target/
@@ -124,7 +124,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts/
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# BRIG v1.1.0
+
+## Highlights
+
+- **Multithreaded BLAST** (#42) — adds `-num_threads` to all BLAST calls; defaults to all available CPUs; configurable via `--threads <n>` CLI option or `blastThreads` XML profile attribute
+- **Fix same-filename collision** (#53) — BLAST output `.tab` files are now prefixed with ring/sequence indices (`r{ring}s{seq}_`) so files with the same name in different directories never overwrite each other
+- **Configurable GC skew/content window** (#56) — new `--gc-window <n>` CLI option and `gcWindow` XML attribute let users set the window size for GC calculations; falls back to auto-scaling when not set
+- **Auto-release workflow** — merging a PR labelled `release` into `master` automatically bumps the patch version, creates a tag, and triggers the existing release pipeline to build DMG/MSI/JAR packages
+
+## Other changes
+
+- Bump `actions/upload-artifact` to v7, `actions/download-artifact` to v8
+- Bump `maven-shade-plugin` from 3.6.1 to 3.6.2
+- CI now installs BLAST+ via pixi and runs E2E tests
+- Added `pixi.toml` for reproducible BLAST+ dependency management
+
+## Downloads
+
+| File | Description |
+|------|-------------|
+| `BRIG.jar` | Cross-platform fat JAR (GUI) |
+| `brig-cli.jar` | Command-line interface JAR |
+| `BRIG-1.1.0.dmg` | macOS installer |
+| `BRIG-1.1.0.msi` | Windows installer |
+
+---
+
+# BRIG v1.0.0
+
+First official release of BRIG (BLAST Ring Image Generator) with a modernised build and native installers.
+
+## Highlights
+
+- **Maven build** — migrated from legacy Ant scripts to a Maven-based build with reproducible dependency management
+- **Native installers** — macOS DMG and Windows MSI produced via `jpackage`, no JRE installation required
+- **CLI mode** — new headless `brig-cli.jar` for scripted/server-side usage alongside the GUI
+- **Java 25** — updated to target the latest JDK
+- **Documentation site** — Material for MkDocs documentation deployed to GitHub Pages
+- **CI/CD** — GitHub Actions pipelines for continuous integration, docs deployment, and automated releases
+- **Test suite** — JUnit 5 tests with JaCoCo code coverage
+
+## Downloads
+
+| File | Description |
+|------|-------------|
+| `BRIG.jar` | Cross-platform fat JAR (GUI) |
+| `brig-cli.jar` | Command-line interface JAR |
+| `BRIG-1.0.0.dmg` | macOS installer |
+| `BRIG-1.0.0.msi` | Windows installer |
+
+## What is BRIG?
+
+BRIG generates circular comparison images of multiple genomes using BLAST. It visualises sequence similarity, GC content, read coverage, and custom annotations as concentric rings around a reference genome.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# BRIG v1.1.0
+# BRIG v1.1.1
 
 ## Highlights
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,9 @@
+[project]
+name = "BRIG"
+version = "1.0.0"
+description = "BLAST Ring Image Generator"
+channels = ["conda-forge", "bioconda"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+
+[dependencies]
+blast = ">=2.16"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "BRIG"
-version = "1.0.0"
+version = "1.1.0"
 description = "BLAST Ring Image Generator"
 channels = ["conda-forge", "bioconda"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,9 +1,9 @@
-[project]
+[workspace]
 name = "BRIG"
 version = "1.0.0"
 description = "BLAST Ring Image Generator"
 channels = ["conda-forge", "bioconda"]
-platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+platforms = ["linux-64", "osx-64", "osx-arm64"]
 
 [dependencies]
 blast = ">=2.16"

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.github.happykhan</groupId>
     <artifactId>brig</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>BRIG</name>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <id>shade-gui</id>

--- a/src/brig/About.form
+++ b/src/brig/About.form
@@ -73,7 +73,7 @@
     </Component>
     <Component class="javax.swing.JLabel" name="versionLabel">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Blast Ring Image Generator (BRIG) Version 0.81"/>
+        <Property name="text" type="java.lang.String" value="Blast Ring Image Generator (BRIG)"/>
       </Properties>
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel2">

--- a/src/brig/About.java
+++ b/src/brig/About.java
@@ -98,11 +98,25 @@ public class About extends javax.swing.JFrame {
             }
         });
 
+        doiLink = new javax.swing.JLabel();
+        doiLink.setText("<html><a href=''>doi: 10.1186/1471-2164-12-402</a></html>");
+        doiLink.setCursor(new Cursor(Cursor.HAND_CURSOR));
+        doiLink.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                try {
+                    Desktop.getDesktop().browse(new URI("https://doi.org/10.1186/1471-2164-12-402"));
+                } catch (Exception ex) {
+                    log.error("Failed to open browser", ex);
+                }
+            }
+        });
+
         jTextArea1.setColumns(20);
         jTextArea1.setLineWrap(true);
         jTextArea1.setRows(5);
         jTextArea1.setEditable(false);
-        jTextArea1.setText("BRIG (BLAST Ring Image Generator) produces CGView-rendered circular\ngenome comparison images based on BLAST output.\n\nBRIG supports:\n*  Genbank/EMBL\n*  FASTA nucleotide; single entry or Multi-FASTA\n*  FASTA protein; single entry or Multi-FASTA\n\nBRIG is free software distributed under the GNU General Public License v3.\n\nFor documentation, source code, and release notes visit:\nhttps://github.com/happykhan/BRIG");
+        jTextArea1.setText("BRIG (BLAST Ring Image Generator) produces CGView-rendered circular\ngenome comparison images based on BLAST output.\n\nBRIG supports:\n*  Genbank/EMBL\n*  FASTA nucleotide; single entry or Multi-FASTA\n*  FASTA protein; single entry or Multi-FASTA\n\nBRIG is free software distributed under the GNU General Public License v3.\n\nFor documentation, source code, and release notes visit:\nhttps://github.com/happykhan/BRIG\n\n--- Citation ---\n\nIf you use BRIG in your research, please cite:\n\nNF Alikhan, NK Petty, NL Ben Zakour, SA Beatson (2011)\nBLAST Ring Image Generator (BRIG): simple prokaryote genome comparisons.\nBMC Genomics, 12:402.\ndoi: 10.1186/1471-2164-12-402");
         jScrollPane1.setViewportView(jTextArea1);
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
@@ -120,7 +134,8 @@ public class About extends javax.swing.JFrame {
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 302, Short.MAX_VALUE)
                                 .addComponent(jButton1))
                             .addComponent(issuesLink)
-                            .addComponent(contactLabel)))
+                            .addComponent(contactLabel)
+                            .addComponent(doiLink)))
                     .addGroup(layout.createSequentialGroup()
                         .addContainerGap()
                         .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 568, Short.MAX_VALUE)))
@@ -139,6 +154,8 @@ public class About extends javax.swing.JFrame {
                 .addComponent(issuesLink)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(contactLabel)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(doiLink)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 420, Short.MAX_VALUE)
                 .addContainerGap())
@@ -167,6 +184,7 @@ public class About extends javax.swing.JFrame {
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel issuesLink;
     private javax.swing.JLabel contactLabel;
+    private javax.swing.JLabel doiLink;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JTextArea jTextArea1;
     private javax.swing.JLabel versionLabel;

--- a/src/brig/About.java
+++ b/src/brig/About.java
@@ -66,7 +66,9 @@ public class About extends javax.swing.JFrame {
             }
         });
 
-        versionLabel.setText("Blast Ring Image Generator (BRIG) Version 0.81");
+        String v = BRIG.class.getPackage().getImplementationVersion();
+        if (v == null) v = "dev";
+        versionLabel.setText("Blast Ring Image Generator (BRIG) Version " + v);
 
         jLabel2.setText("Copyright Nabil Alikhan. 2010-2025.");
 

--- a/src/brig/BRIG.java
+++ b/src/brig/BRIG.java
@@ -707,6 +707,7 @@ public class BRIG extends Thread{
         String queryFastaFile = PROFILE.getRootElement().getAttributeValue("queryFastaFile");
         String output = PROFILE.getRootElement().getAttributeValue("outputFolder");
         String blastOptions = PROFILE.getRootElement().getAttributeValue("blastOptions");
+        if (blastOptions == null) blastOptions = "";
         String blastLocation = "";
         if (PROFILE.getRootElement().getChild("brig_settings") != null) {
             if (PROFILE.getRootElement().getChild("brig_settings").getAttributeValue("blastLocation") != null) {
@@ -718,7 +719,9 @@ public class BRIG extends Thread{
                 }
             }
         }
-        Print( "Reference sequence length: " + NumberFormat.getInstance().format(BRIG.GEN_LENGTH) + " bp");
+        int numThreads = BlastSettings.getBlastThreads();
+        Print("Reference sequence length: " + NumberFormat.getInstance().format(BRIG.GEN_LENGTH) + " bp");
+        Print("BLAST threads: " + numThreads);
         for (int i = 0; i < ringList.size(); i++) {
             Element currentRing = ringList.get(i);
             String ringName = currentRing.getAttributeValue("name");
@@ -807,6 +810,9 @@ public class BRIG extends Thread{
                             if ("blastp".equals(blastType) || "blastn".equals(blastType)) {
                                 blastCmd.addAll(Arrays.asList("-task", blastType));
                             }
+                        }
+                        if (numThreads > 1 && !blastOptions.contains("-num_threads")) {
+                            blastCmd.addAll(Arrays.asList("-num_threads", String.valueOf(numThreads)));
                         }
                         sequence.get(j).setAttribute("blastResults", ou);
                         File blOut = new File(ou);

--- a/src/brig/BRIG.java
+++ b/src/brig/BRIG.java
@@ -721,7 +721,11 @@ public class BRIG extends Thread{
         }
         int numThreads = BlastSettings.getBlastThreads();
         Print("Reference sequence length: " + NumberFormat.getInstance().format(BRIG.GEN_LENGTH) + " bp");
-        Print("BLAST threads: " + numThreads);
+        if (blastOptions.contains("-num_threads")) {
+            Print("BLAST threads: set in blast options");
+        } else {
+            Print("BLAST threads: " + numThreads);
+        }
         for (int i = 0; i < ringList.size(); i++) {
             Element currentRing = ringList.get(i);
             String ringName = currentRing.getAttributeValue("name");
@@ -802,9 +806,7 @@ public class BRIG extends Thread{
                         } else {
                             Print("  Database exists, reusing cached.");
                         }
-                        // Prefix with ring/sequence index to avoid collision when two files
-                        // share the same name but live in different directories (issue #53)
-                        String ou = output + SL + "scratch" + SL + "r" + i + "s" + j + "_" + FetchFilename(goodRingFile) + "Vs" + FetchFilename(queryFastaFile) + ".tab";
+                        String ou = blastOutputPath(output, i, j, goodRingFile, queryFastaFile);
                         List<String> blastCmd = new ArrayList<>();
                         blastCmd.addAll(Arrays.asList(blastLocation + blastType, "-outfmt", "6", "-query", goodRingFile, "-db", queryFastaFile, "-out", ou));
                         blastCmd.addAll(tokenizeOptions(blastOptions));
@@ -1243,6 +1245,13 @@ public class BRIG extends Thread{
                         if (starte == 0) {
                             starte = 1;
                         }
+                        if (starte > GEN_LENGTH) {
+                            lineNum++;
+                            continue;
+                        }
+                        if (stope > (GEN_LENGTH - 1)) {
+                            stope = GEN_LENGTH - 1;
+                        }
                         if ((temp / custom) >= 1) {
                             out.write("<featureRange color=\"blue\" start=\"" + starte + "\" stop=\"" + stope + "\" "
                                     + "proportionOfThickness=\"1\" />");
@@ -1261,6 +1270,17 @@ public class BRIG extends Thread{
             } catch (Exception e) {
                 log.error("Error processing graph line: {}", line, e);
             }
+        }
+
+        // Check if graph data exceeds sequence length — warn and skip
+        int maxStart = 0;
+        for (int s : start) { if (s > maxStart) maxStart = s; }
+        if (maxStart > GEN_LENGTH) {
+            Print("  WARNING: Graph file '" + new File(location).getName()
+                    + "' has coordinates (max " + maxStart + ") exceeding reference length ("
+                    + GEN_LENGTH + " bp). Skipping this ring.");
+            out.write("</feature>\n");
+            return error;
         }
 
         //IF CUSTOM VALUES HIDE THIS ALL AWAY
@@ -1300,6 +1320,10 @@ public class BRIG extends Thread{
                 int stope = stop.get(j);
                 if (stope > (GEN_LENGTH - 1)) {
                     stope = GEN_LENGTH - 1;
+                }
+                // Skip entries where start exceeds the sequence length
+                if (starte > GEN_LENGTH) {
+                    continue;
                 }
                 if (barHeight > 1 && radiusShift < 0) {
                     //         Print( skew + "\t" +"\t" +barHeight +"\t" +radiusShift  +"\tSmall");
@@ -1377,187 +1401,126 @@ public class BRIG extends Thread{
         return error;
     }
 
+    /**
+     * Reads all non-header bases from a FASTA file into a single StringBuilder,
+     * recording contig boundaries (with spacer offsets) for multi-contig files.
+     */
+    private static class SequenceData {
+        final StringBuilder seq = new StringBuilder();
+        final List<int[]> contigBoundaries = new ArrayList<>(); // [start, spacerAfter]
+    }
+
+    private static SequenceData readSequence(String fastaFile) throws IOException {
+        SequenceData data = new SequenceData();
+        int contigStart = 0;
+        int contigCount = 0;
+        int spacer = 0;
+        if (PROFILE != null && PROFILE.getRootElement().getAttributeValue("spacer") != null) {
+            try { spacer = Integer.parseInt(PROFILE.getRootElement().getAttributeValue("spacer")); }
+            catch (NumberFormatException ignored) {}
+        }
+        try (BufferedReader rdr = new BufferedReader(new FileReader(fastaFile))) {
+            String line;
+            while ((line = rdr.readLine()) != null) {
+                if (line.startsWith(">")) {
+                    if (contigCount > 0 && spacer > 0) {
+                        data.contigBoundaries.add(new int[]{contigStart, spacer});
+                        contigStart = data.seq.length() + spacer;
+                    }
+                    contigCount++;
+                } else {
+                    data.seq.append(line.toUpperCase());
+                }
+            }
+        }
+        return data;
+    }
+
+    private static int countGC(CharSequence seq, int from, int to) {
+        int gc = 0;
+        for (int i = from; i < to; i++) {
+            char c = seq.charAt(i);
+            if (c == 'G' || c == 'C') gc++;
+        }
+        return gc;
+    }
+
+    /**
+     * Computes the sliding-window step size. For small sequences we use 1 bp
+     * steps so every arc is narrow and the plot looks smooth; for large genomes
+     * we use div/2 to keep the XML size reasonable.
+     */
+    private static int gcStep(int div, int seqLen) {
+        // Target ~3000 output segments; never less than 1
+        return Math.max(1, Math.min(div / 2, seqLen / 3000));
+    }
+
     private static String CGContent(BufferedWriter out, String QUERY_MASTER_FILE) throws IOException {
         int div = resolveGcWindow();
         String error = "";
-        int len = 0;
-        int cPlusG = 0;
-        int totalLen = 0;
+        SequenceData data = readSequence(QUERY_MASTER_FILE);
+        StringBuilder seq = data.seq;
+        int seqLen = seq.length();
+        int step = gcStep(div, seqLen);
+
+        // First pass: compute stats
         double average = 0.0;
-        double maxDeviation = 0.0;
         double min = 10.0;
         double max = 0.0;
         int totalWindow = 0;
-        String color = "";
-        String line = "";
-        out.write("<feature decoration=\"arc\" opacity = \"1.0\">");
-        out.newLine();
-        try (BufferedReader first = new BufferedReader(new FileReader(QUERY_MASTER_FILE))) {
-            while ((line = first.readLine()) != null) {
-                if (!line.contains(">")) {
-                    for (int f = 0; f < line.length(); f++) {
-                        if (len >= div) {
-                            double skew = (double) cPlusG / (double) len;
-                            skew = 0.5 + skew / 2.0;
-                            if ((cPlusG) == 0) {
-                                skew = 0.5;
-                            }
-                            average += skew;
-                            if (skew > max) {
-                                max = skew;
-                            }
-                            if (skew < min) {
-                                min = skew;
-                            }
-                            cPlusG = 0;
-                            totalLen += len;
-                            len = 0;
-                            totalWindow++;
-                        }
-                        int G = "G".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                        int C = "C".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                        if (C == 0 || G == 0) {
-                            cPlusG++;
-                        }
-                        len++;
-                    }
-                }
-            }
-        }
-        if (len > 0) {
-            double skew = (double) cPlusG / (double) len;
-            skew = 0.5 + skew / 2.0;
-            if ((cPlusG) == 0) {
-                skew = 0.5;
-            }
+        for (int pos = 0; pos + div <= seqLen; pos += step) {
+            int gc = countGC(seq, pos, pos + div);
+            double skew = (gc == 0) ? 0.5 : 0.5 + ((double) gc / div) / 2.0;
             average += skew;
-            if (skew > max) {
-                max = skew;
-            }
-            if (skew < min) {
-                min = skew;
-            }
+            if (skew > max) max = skew;
+            if (skew < min) min = skew;
+            totalWindow++;
         }
-        average = average / (double) totalWindow;
-        if ((max - average) > (average - min)) {
-            maxDeviation = max - average;
-        } else {
-            maxDeviation = average - min;
-        }
-        len = 0;
-        cPlusG = 0;
-        totalLen = 1;
-        double radiusShift = 0.0;
-        double barHeight = 0.0;
+        if (totalWindow == 0) { out.write("<feature decoration=\"arc\" opacity = \"1.0\"></feature>"); out.newLine(); return ""; }
+        average /= totalWindow;
+        double maxDeviation = Math.max(max - average, average - min);
+        if (maxDeviation == 0) maxDeviation = 1;
+
         error += ("Maximum value:  " + max + "\n");
         error += ("Minimum value:  " + min + "\n");
         error += ("Average value: " + average + "\n\n");
-        try (BufferedReader first2 = new BufferedReader(new FileReader(QUERY_MASTER_FILE))) {
-        int lineCount = 0;
-        while ((line = first2.readLine()) != null) {
-            if (line.contains(">")) {
-                lineCount++;
-            }
-            if (line.contains(">") && lineCount > 1) {
-                if (BRIG.PROFILE.getRootElement().getAttributeValue("spacer") != null) {
-                    if (Integer.parseInt(BRIG.PROFILE.getRootElement().getAttributeValue("spacer")) > 0) {
-                        double skew = (double) cPlusG / (double) len;
-                        skew = 0.5 + skew / 2.0;
-                        if ((cPlusG) == 0) {
-                            skew = 0.5;
-                        }
-                        if (skew > average) {
-                            color = "rgb(0,0,0)";
-                            barHeight = skew - average;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 + barHeight / 2.0;
-                        } else if (skew < average) {
-                            color = "rgb(0,0,0)";
-                            barHeight = average - skew;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 - barHeight / 2.0;
-                        } else {
-                            color = "rgb(0,0,0)";
-                            radiusShift = 0.5;
-                        }
-                        if((totalLen + len) < GEN_LENGTH  ){
-                        out.write("<featureRange color=\"" + color + "\" start=\"" + totalLen + "\" stop=\"" + (totalLen + len) + "\" "
-                                + "proportionOfThickness=\"" + barHeight + "\" radiusAdjustment=\"" + radiusShift + "\" />");
-                        }
-                        out.newLine();
-                        cPlusG = 0;
-                        totalLen += len;
-                        len = 0;
-                        totalLen += Integer.parseInt(BRIG.PROFILE.getRootElement().getAttributeValue("spacer"));
-                    }
-                }
-            } else if (!line.contains(">")) {
-                for (int f = 0; f < line.length(); f++) {
-                    if (len >= div) {
-                        double skew = (double) cPlusG / (double) len;
-                        skew = 0.5 + skew / 2.0;
-                        if ((cPlusG) == 0) {
-                            skew = 0.5;
-                        }
-                        if (skew > average) {
-                            color = "rgb(0,0,0)";
-                            barHeight = skew - average;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 + barHeight / 2.0;
-                        } else if (skew < average) {
-                            color = "rgb(0,0,0)";
-                            barHeight = average - skew;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 - barHeight / 2;
-                        } else {
-                            color = "rgb(0,0,0)";
-                            radiusShift = 0.5;
-                        }
-                        if((totalLen + len) < GEN_LENGTH  ){
-                        out.write("<featureRange color=\"" + color + "\" start=\"" + totalLen + "\" stop=\"" + (totalLen + len) + "\" "
-                                + "proportionOfThickness=\"" + barHeight + "\" radiusAdjustment=\"" + radiusShift + "\" />");
-                        }
-                        out.newLine();
-                        cPlusG = 0;
-                        totalLen += len;
-                        len = 0;
-                    }
-                    int G = "G".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                    int C = "C".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                    if (C == 0 || G == 0) {
-                        cPlusG++;
-                    }
-                    len++;
-                }
-            }
 
-        }
-        }
-        if (len > 0) {
-            double skew = (double) cPlusG / (double) len;
-            skew = 0.5 + skew / 2.0;
-            if ((cPlusG) == 0) {
-                skew = 0.5;
+        // Second pass: write features with sliding window
+        out.write("<feature decoration=\"arc\" opacity = \"1.0\">");
+        out.newLine();
+        int spacerOffset = 0;
+        int boundaryIdx = 0;
+
+        int lastPos = seqLen - div; // inclusive upper bound so we cover the tail
+        for (int pos = 0; pos <= lastPos; pos += step) {
+            // Adjust for contig spacers
+            while (boundaryIdx < data.contigBoundaries.size() && pos >= data.contigBoundaries.get(boundaryIdx)[0]) {
+                spacerOffset += data.contigBoundaries.get(boundaryIdx)[1];
+                boundaryIdx++;
             }
+            int gc = countGC(seq, pos, pos + div);
+            double skew = (gc == 0) ? 0.5 : 0.5 + ((double) gc / div) / 2.0;
+            double barHeight;
+            double radiusShift;
             if (skew > average) {
-                color = "rgb(0,0,0)";
-                barHeight = skew - average;
-                barHeight = barHeight * 0.5 / maxDeviation;
+                barHeight = (skew - average) * 0.5 / maxDeviation;
                 radiusShift = 0.5 + barHeight / 2.0;
             } else if (skew < average) {
-                color = "rgb(0,0,0)";
-                barHeight = average - skew;
-                barHeight = barHeight * 0.5 / maxDeviation;
-                radiusShift = 0.5 - barHeight / 2;
+                barHeight = (average - skew) * 0.5 / maxDeviation;
+                radiusShift = 0.5 - barHeight / 2.0;
             } else {
-                color = "rgb(0,0,0)";
+                barHeight = 0;
                 radiusShift = 0.5;
             }
-            if((totalLen + len) < GEN_LENGTH  ){
-            out.write("<featureRange color=\"" + color + "\" start=\"" + totalLen + "\" stop=\"" + (totalLen + len) + "\" "
-                    + "proportionOfThickness=\"" + barHeight + "\" radiusAdjustment=\"" + radiusShift + "\" />");
-          }
-            out.newLine();
+            int start = pos + 1 + spacerOffset;
+            boolean lastSegment = (pos + step > lastPos);
+            int segEnd = lastSegment ? seqLen : pos + step;
+            int stop = segEnd + spacerOffset;
+            if (stop <= GEN_LENGTH) {
+                out.write("<featureRange color=\"rgb(0,0,0)\" start=\"" + start + "\" stop=\"" + stop + "\" "
+                        + "proportionOfThickness=\"" + barHeight + "\" radiusAdjustment=\"" + radiusShift + "\" />");
+                out.newLine();
+            }
         }
         out.write("</feature>");
         out.newLine();
@@ -1565,185 +1528,109 @@ public class BRIG extends Thread{
     }
 
     private static String CGskew(BufferedWriter out, String QUERY_MASTER_FILE) throws IOException {
-        String error = "";
         int div = resolveGcWindow();
-        out.write("<feature decoration=\"arc\" opacity = \"1.0\">");
-        out.newLine();
-        int len = 0;
-        int cPlusG = 0;
-        int cMinusG = 0;
-        int totalLen = 0;
+        String error = "";
+        SequenceData data = readSequence(QUERY_MASTER_FILE);
+        StringBuilder seq = data.seq;
+        int seqLen = seq.length();
+        int step = gcStep(div, seqLen);
+
+        // First pass: compute stats
         double average = 0.0;
-        double maxDeviation = 0.0;
         double min = 10.0;
         double max = 0.0;
         int totalWindow = 0;
-        String color = "";
-        String line = "";
-        try (BufferedReader first = new BufferedReader(new FileReader(QUERY_MASTER_FILE))) {
-        while ((line = first.readLine()) != null) {
-            if (!line.contains(">")) {
-                for (int f = 0; f
-                        < line.length(); f++) {
-                    if (len >= div) {
-                        double skew = (double) cMinusG / (double) cPlusG;
-                        skew = 0.5 + skew / 2.0;
-                        if ((cPlusG) == 0) {
-                            skew = 0.5;
-                        }
-                        average += skew;
-                        if (skew > max) {
-                            max = skew;
-                        }
-                        if (skew < min) {
-                            min = skew;
-                        }
-                        cPlusG = 0;
-                        cMinusG = 0;
-                        totalLen += len;
-                        len = 0;
-                        totalWindow++;
-                    }
-                    int G = "G".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                    int C = "C".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                    if (C == 0) {
-                        cMinusG++;
-                        cPlusG++;
-                    } else if (G == 0) {
-                        cMinusG--;
-                        cPlusG++;
-                    }
-                    len++;
-                }
+        for (int pos = 0; pos + div <= seqLen; pos += step) {
+            int cPlusG = 0, cMinusG = 0;
+            for (int i = pos; i < pos + div; i++) {
+                char c = seq.charAt(i);
+                if (c == 'C') { cPlusG++; cMinusG++; }
+                else if (c == 'G') { cPlusG++; cMinusG--; }
             }
-        }
-        if (len > 0) {
-            double skew = (double) cMinusG / (double) cPlusG;
-            skew = 0.5 + skew / 2.0;
-            if ((cPlusG) == 0) {
-                skew = 0.5;
-            }
+            double skew = (cPlusG == 0) ? 0.5 : 0.5 + ((double) cMinusG / cPlusG) / 2.0;
             average += skew;
-            if (skew > max) {
-                max = skew;
-            }
-            if (skew < min) {
-                min = skew;
-            }
+            if (skew > max) max = skew;
+            if (skew < min) min = skew;
+            totalWindow++;
         }
-        average = average / (double) totalWindow;
-        if ((max - average) > (average - min)) {
-            maxDeviation = max - average;
-        } else {
-            maxDeviation = average - min;
-        }
-        }
-        len = 0;
-        cPlusG = 0;
-        cMinusG = 0;
-        totalLen = 1;
-        double radiusShift = 0.0;
-        double barHeight = 0.0;
+        if (totalWindow == 0) { out.write("<feature decoration=\"arc\" opacity = \"1.0\"></feature>"); out.newLine(); return ""; }
+        average /= totalWindow;
+        double maxDeviation = Math.max(max - average, average - min);
+        if (maxDeviation == 0) maxDeviation = 1;
+
         error += ("Maximum value:  " + max + "\n");
         error += ("Minimum value:  " + min + "\n");
         error += ("Average value: " + average + "\n\n");
-        try (BufferedReader first2 = new BufferedReader(new FileReader(QUERY_MASTER_FILE))) {
-        int lineCount = 0;
-        while ((line = first2.readLine()) != null) {
-            if (line.contains(">")) {
-                lineCount++;
+
+        // Second pass: write features with sliding window
+        out.write("<feature decoration=\"arc\" opacity = \"1.0\">");
+        out.newLine();
+        int spacerOffset = 0;
+        int boundaryIdx = 0;
+
+        int lastPos = seqLen - div;
+        for (int pos = 0; pos <= lastPos; pos += step) {
+            while (boundaryIdx < data.contigBoundaries.size() && pos >= data.contigBoundaries.get(boundaryIdx)[0]) {
+                spacerOffset += data.contigBoundaries.get(boundaryIdx)[1];
+                boundaryIdx++;
             }
-            if (line.contains(">") && lineCount > 1) {
-                if (BRIG.PROFILE.getRootElement().getAttributeValue("spacer") != null) {
-                    if (Integer.parseInt(BRIG.PROFILE.getRootElement().getAttributeValue("spacer")) > 0) {
-                        double skew = (double) cMinusG / (double) cPlusG;
-                        skew = 0.5 + skew / 2.0;
-                        if ((cPlusG) == 0) {
-                            skew = 0.5;
-                        }
-                        if (skew > average) {
-                            color = "rgb(152,0,152)";
-                            barHeight = skew - average;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 + barHeight / 2.0;
-                        } else if (skew < average) {
-                            color = "rgb(0,152,0)";
-                            barHeight = average - skew;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 - barHeight / 2;
-                        } else {
-                            color = "rgb(152,0,152)";
-                            radiusShift = 0.5;
-                        }
-                        cMinusG = 0;
-                        cPlusG = 0;
-                        totalLen += len;
-                        len = 0;
-                        totalLen += Integer.parseInt(BRIG.PROFILE.getRootElement().getAttributeValue("spacer"));
-                    }
-                }
+            int cPlusG = 0, cMinusG = 0;
+            for (int i = pos; i < pos + div; i++) {
+                char c = seq.charAt(i);
+                if (c == 'C') { cPlusG++; cMinusG++; }
+                else if (c == 'G') { cPlusG++; cMinusG--; }
             }
-            if (!line.contains(">")) {
-                for (int f = 0; f < line.length(); f++) {
-                    if (len >= div) {
-                        double skew = (double) cMinusG / (double) cPlusG;
-                        skew = 0.5 + skew / 2.0;
-                        if ((cPlusG) == 0) {
-                            skew = 0.5;
-                        }
-                        if (skew > average) {
-                            color = "rgb(152,0,152)";
-                            barHeight = skew - average;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 + barHeight / 2.0;
-                        } else if (skew < average) {
-                            color = "rgb(0,152,0)";
-                            barHeight = average - skew;
-                            barHeight = barHeight * 0.5 / maxDeviation;
-                            radiusShift = 0.5 - barHeight / 2;
-                        } else {
-                            color = "rgb(152,0,152)";
-                            radiusShift = 0.5;
-                        }
-                        out.write("<featureRange color=\"" + color + "\" start=\"" + totalLen + "\" stop=\"" + (totalLen + len) + "\" "
-                                + "proportionOfThickness=\"" + barHeight + "\" radiusAdjustment=\"" + radiusShift + "\" />");
-                        out.newLine();
-                        cPlusG = 0;
-                        cMinusG = 0;
-                        totalLen += len;
-                        len = 0;
-                    }
-                    int G = "G".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                    int C = "C".compareToIgnoreCase(String.valueOf(line.charAt(f)));
-                    if (C == 0) {
-                        cMinusG++;
-                        cPlusG++;
-                    } else if (G == 0) {
-                        cMinusG--;
-                        cPlusG++;
-                    }
-                    len++;
-                }
+            double skew = (cPlusG == 0) ? 0.5 : 0.5 + ((double) cMinusG / cPlusG) / 2.0;
+            String color;
+            double barHeight, radiusShift;
+            if (skew > average) {
+                color = "rgb(152,0,152)";
+                barHeight = (skew - average) * 0.5 / maxDeviation;
+                radiusShift = 0.5 + barHeight / 2.0;
+            } else if (skew < average) {
+                color = "rgb(0,152,0)";
+                barHeight = (average - skew) * 0.5 / maxDeviation;
+                radiusShift = 0.5 - barHeight / 2.0;
+            } else {
+                color = "rgb(152,0,152)";
+                barHeight = 0;
+                radiusShift = 0.5;
             }
-        }
-        }
-        if (len > 0) {
-            double skew = (double) cMinusG / (double) cPlusG;
-            skew = 0.5 + skew / 2.0;
-            if ((cPlusG) == 0) {
-                skew = 0.5;
+            int start = pos + 1 + spacerOffset;
+            boolean lastSegment = (pos + step > lastPos);
+            int segEnd = lastSegment ? seqLen : pos + step;
+            int stop = segEnd + spacerOffset;
+            if (stop <= GEN_LENGTH) {
+                out.write("<featureRange color=\"" + color + "\" start=\"" + start + "\" stop=\"" + stop + "\" "
+                        + "proportionOfThickness=\"" + barHeight + "\" radiusAdjustment=\"" + radiusShift + "\" />");
+                out.newLine();
             }
-            out.write("<featureRange color=\"rgb(0,0,0)\" start=\"" + totalLen + "\" stop=\"" + (totalLen + len - 2) + "\" "
-                    + "proportionOfThickness=\"" + skew + "\" radiusAdjustment=\"0.5\" />");
-            out.newLine();
         }
         out.write("</feature>");
         out.newLine();
         return error;
     }
 
+    /**
+     * Auto-scales the GC window size so there are ~3000 segments around the ring.
+     * Enforces a minimum of 50 bp so small sequences (e.g. plasmids) have
+     * enough bases per window for smooth GC variation. The sliding window
+     * in CGContent/CGskew (step = window/2) then produces many overlapping
+     * segments for visual smoothness.
+     */
     public  static int autoScale(int length  ){
-        return (length / 3000);
+        return Math.max(50, length / 3000);
+    }
+
+    /**
+     * Builds the BLAST output .tab path, prefixed with ring/sequence indices
+     * to avoid collision when two files share the same name (issue #53).
+     */
+    public static String blastOutputPath(String outputFolder, int ringIndex, int seqIndex,
+                                          String ringFile, String queryFile) {
+        return outputFolder + SL + "scratch" + SL
+                + "r" + ringIndex + "s" + seqIndex + "_"
+                + FetchFilename(ringFile) + "Vs" + FetchFilename(queryFile) + ".tab";
     }
 
     /**

--- a/src/brig/BRIG.java
+++ b/src/brig/BRIG.java
@@ -802,7 +802,9 @@ public class BRIG extends Thread{
                         } else {
                             Print("  Database exists, reusing cached.");
                         }
-                        String ou = output + SL + "scratch" + SL + FetchFilename(goodRingFile) + "Vs" + FetchFilename(queryFastaFile) + ".tab";
+                        // Prefix with ring/sequence index to avoid collision when two files
+                        // share the same name but live in different directories (issue #53)
+                        String ou = output + SL + "scratch" + SL + "r" + i + "s" + j + "_" + FetchFilename(goodRingFile) + "Vs" + FetchFilename(queryFastaFile) + ".tab";
                         List<String> blastCmd = new ArrayList<>();
                         blastCmd.addAll(Arrays.asList(blastLocation + blastType, "-outfmt", "6", "-query", goodRingFile, "-db", queryFastaFile, "-out", ou));
                         blastCmd.addAll(tokenizeOptions(blastOptions));
@@ -1376,7 +1378,7 @@ public class BRIG extends Thread{
     }
 
     private static String CGContent(BufferedWriter out, String QUERY_MASTER_FILE) throws IOException {
-        int div = autoScale(GEN_LENGTH);
+        int div = resolveGcWindow();
         String error = "";
         int len = 0;
         int cPlusG = 0;
@@ -1564,7 +1566,7 @@ public class BRIG extends Thread{
 
     private static String CGskew(BufferedWriter out, String QUERY_MASTER_FILE) throws IOException {
         String error = "";
-        int div = autoScale(GEN_LENGTH);
+        int div = resolveGcWindow();
         out.write("<feature decoration=\"arc\" opacity = \"1.0\">");
         out.newLine();
         int len = 0;
@@ -1742,6 +1744,25 @@ public class BRIG extends Thread{
 
     public  static int autoScale(int length  ){
         return (length / 3000);
+    }
+
+    /**
+     * Returns the GC skew/content window size.
+     * Reads {@code gcWindow} from {@code brig_settings} if set (issue #56);
+     * falls back to {@link #autoScale(int)} otherwise.
+     */
+    public static int resolveGcWindow() {
+        if (PROFILE != null && PROFILE.getRootElement().getChild("brig_settings") != null) {
+            String val = PROFILE.getRootElement().getChild("brig_settings").getAttributeValue("gcWindow");
+            if (val != null && !val.isEmpty()) {
+                try {
+                    int w = Integer.parseInt(val);
+                    if (w > 0) return w;
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        return autoScale(GEN_LENGTH);
     }
 }
 

--- a/src/brig/BRIGcli.java
+++ b/src/brig/BRIGcli.java
@@ -33,6 +33,7 @@ public class BRIGcli {
         String title = null;
         String format = "png";
         String configPath = null;
+        int threads = 0;
         boolean gcContent = false;
         boolean gcSkew = false;
 
@@ -50,6 +51,16 @@ public class BRIGcli {
                     break;
                 case "--config":
                     if (i + 1 < args.length) configPath = args[++i];
+                    break;
+                case "--threads":
+                    if (i + 1 < args.length) {
+                        try {
+                            threads = Integer.parseInt(args[++i]);
+                        } catch (NumberFormatException e) {
+                            System.err.println("Error: --threads requires a numeric value");
+                            System.exit(1);
+                        }
+                    }
                     break;
                 case "--gc-content":
                     gcContent = true;
@@ -131,6 +142,14 @@ public class BRIGcli {
         // Apply JSON config overrides if provided
         if (configPath != null) {
             applyJsonConfig(configPath);
+        }
+
+        // Set thread count if specified
+        if (threads > 0) {
+            Element brigSettings = BRIG.PROFILE.getRootElement().getChild("brig_settings");
+            if (brigSettings != null) {
+                brigSettings.setAttribute("blastThreads", String.valueOf(threads));
+            }
         }
 
         // Set profile attributes
@@ -477,6 +496,7 @@ public class BRIGcli {
         System.out.println("  --gc-content         Add GC Content ring");
         System.out.println("  --gc-skew            Add GC Skew ring");
         System.out.println("  --config <path>      JSON config file for settings overrides");
+        System.out.println("  --threads <n>        Number of threads for BLAST (default: all CPUs)");
         System.out.println("  --help, -h           Show this help message");
         System.out.println();
         System.out.println("Examples:");

--- a/src/brig/BRIGcli.java
+++ b/src/brig/BRIGcli.java
@@ -36,6 +36,7 @@ public class BRIGcli {
         int threads = 0;
         boolean gcContent = false;
         boolean gcSkew = false;
+        int gcWindow = 0;
 
         int i = 0;
         while (i < args.length) {
@@ -67,6 +68,16 @@ public class BRIGcli {
                     break;
                 case "--gc-skew":
                     gcSkew = true;
+                    break;
+                case "--gc-window":
+                    if (i + 1 < args.length) {
+                        try {
+                            gcWindow = Integer.parseInt(args[++i]);
+                        } catch (NumberFormatException e) {
+                            System.err.println("Error: --gc-window requires a numeric value");
+                            System.exit(1);
+                        }
+                    }
                     break;
                 case "--help":
                 case "-h":
@@ -149,6 +160,14 @@ public class BRIGcli {
             Element brigSettings = BRIG.PROFILE.getRootElement().getChild("brig_settings");
             if (brigSettings != null) {
                 brigSettings.setAttribute("blastThreads", String.valueOf(threads));
+            }
+        }
+
+        // Set GC window size if specified (issue #56)
+        if (gcWindow > 0) {
+            Element brigSettings = BRIG.PROFILE.getRootElement().getChild("brig_settings");
+            if (brigSettings != null) {
+                brigSettings.setAttribute("gcWindow", String.valueOf(gcWindow));
             }
         }
 
@@ -495,6 +514,7 @@ public class BRIGcli {
         System.out.println("  --format <fmt>       Image format: png, jpg, svg, svgz (default: png)");
         System.out.println("  --gc-content         Add GC Content ring");
         System.out.println("  --gc-skew            Add GC Skew ring");
+        System.out.println("  --gc-window <n>      Window size for GC skew/content calculation (default: auto)");
         System.out.println("  --config <path>      JSON config file for settings overrides");
         System.out.println("  --threads <n>        Number of threads for BLAST (default: all CPUs)");
         System.out.println("  --help, -h           Show this help message");

--- a/src/brig/BlastSettings.java
+++ b/src/brig/BlastSettings.java
@@ -21,6 +21,22 @@ public class BlastSettings {
 
     private static final Logger log = LoggerFactory.getLogger(BlastSettings.class);
 
+    public static int getBlastThreads() {
+        int defaultThreads = Runtime.getRuntime().availableProcessors();
+        if (BRIG.PROFILE == null) return defaultThreads;
+        Element settings = BRIG.PROFILE.getRootElement().getChild("brig_settings");
+        if (settings != null) {
+            String val = settings.getAttributeValue("blastThreads");
+            if (val != null) {
+                try {
+                    int t = Integer.parseInt(val);
+                    if (t > 0) return t;
+                } catch (NumberFormatException e) { /* use default */ }
+            }
+        }
+        return defaultThreads;
+    }
+
     public static String BlastOption(String opt) {
         var error = new StringBuilder("BLAST+ option error: ");
         var noBlast = new String[]{

--- a/src/brig/BlastSettings.java
+++ b/src/brig/BlastSettings.java
@@ -22,7 +22,7 @@ public class BlastSettings {
     private static final Logger log = LoggerFactory.getLogger(BlastSettings.class);
 
     public static int getBlastThreads() {
-        int defaultThreads = Runtime.getRuntime().availableProcessors();
+        int defaultThreads = Math.min(2, Runtime.getRuntime().availableProcessors());
         if (BRIG.PROFILE == null) return defaultThreads;
         Element settings = BRIG.PROFILE.getRootElement().getChild("brig_settings");
         if (settings != null) {

--- a/src/brig/CustomXML.java
+++ b/src/brig/CustomXML.java
@@ -593,10 +593,11 @@ public class CustomXML extends javax.swing.JFrame {
     }//GEN-LAST:event_inputDataItemStateChanged
 
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
-        File text = new File (fileLocation.getText());
+        String fieldText = fileLocation.getText();
         JFileChooser fc = new JFileChooser();
-        if (text.exists()) {
-            if (text.getParentFile().isDirectory()) {
+        if (fieldText != null && !fieldText.isEmpty()) {
+            File text = new File(fieldText);
+            if (text.exists() && text.getParentFile() != null && text.getParentFile().isDirectory()) {
                 fc = new JFileChooser(text.getParent());
             }
         }

--- a/src/brig/Graph.java
+++ b/src/brig/Graph.java
@@ -750,6 +750,11 @@ public class Graph extends javax.swing.JFrame {
                 List<String> blastCmd = new ArrayList<>();
                 blastCmd.addAll(Arrays.asList(blastLocation + "blastn", "-outfmt", "6", "-query", queryField.getText(), "-db", sequenceAddField.getText(), "-out", ou));
                 blastCmd.addAll(BRIG.tokenizeOptions(blastOptionField.getText()));
+                int graphThreads = BlastSettings.getBlastThreads();
+                String blastOptText = blastOptionField.getText();
+                if (graphThreads > 1 && (blastOptText == null || !blastOptText.contains("-num_threads"))) {
+                    blastCmd.addAll(Arrays.asList("-num_threads", String.valueOf(graphThreads)));
+                }
                 exec = BRIG.formatCommand(blastCmd);
                 updateProgress(exec);
                 p = BRIG.execCommand(blastCmd);

--- a/src/brig/Graph.java
+++ b/src/brig/Graph.java
@@ -86,6 +86,7 @@ public class Graph extends javax.swing.JFrame {
         refBrowseButton = new javax.swing.JButton();
         jButton1 = new javax.swing.JButton();
         blastOptionField = new javax.swing.JTextField();
+        blastOptionField.setText("-evalue 1e-5 -num_threads " + BlastSettings.getBlastThreads());
         jLabel5 = new javax.swing.JLabel();
         jLabel4 = new javax.swing.JLabel();
         outputFolderField = new javax.swing.JTextField();
@@ -333,10 +334,15 @@ public class Graph extends javax.swing.JFrame {
             }
             }
         }
-        fc.setFileSelectionMode(fc.DIRECTORIES_ONLY);
-        fc.showOpenDialog(this);       
-        if (fc.getSelectedFile() != null) {
-            outputFolderField.setText(fc.getSelectedFile().getAbsolutePath());
+        fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        fc.setDialogTitle("Select output folder");
+        int result = fc.showDialog(this, "Select");
+        if (result == JFileChooser.APPROVE_OPTION && fc.getSelectedFile() != null) {
+            File selected = fc.getSelectedFile();
+            if (!selected.exists()) {
+                selected.mkdirs();
+            }
+            outputFolderField.setText(selected.getAbsolutePath());
         }
 }//GEN-LAST:event_outputBrowseButtonActionPerformed
 
@@ -749,10 +755,10 @@ public class Graph extends javax.swing.JFrame {
                 updateProgress("Success!");
                 List<String> blastCmd = new ArrayList<>();
                 blastCmd.addAll(Arrays.asList(blastLocation + "blastn", "-outfmt", "6", "-query", queryField.getText(), "-db", sequenceAddField.getText(), "-out", ou));
-                blastCmd.addAll(BRIG.tokenizeOptions(blastOptionField.getText()));
+                String blastOptText = blastOptionField.getText() != null ? blastOptionField.getText() : "";
+                blastCmd.addAll(BRIG.tokenizeOptions(blastOptText));
                 int graphThreads = BlastSettings.getBlastThreads();
-                String blastOptText = blastOptionField.getText();
-                if (graphThreads > 1 && (blastOptText == null || !blastOptText.contains("-num_threads"))) {
+                if (graphThreads > 1 && !blastOptText.contains("-num_threads")) {
                     blastCmd.addAll(Arrays.asList("-num_threads", String.valueOf(graphThreads)));
                 }
                 exec = BRIG.formatCommand(blastCmd);

--- a/src/brig/GraphFunctions.java
+++ b/src/brig/GraphFunctions.java
@@ -261,6 +261,10 @@ public static String parseBlast2Graph(int[] value, int[] repeats, String input, 
                                 }
                                 blastCmd.addAll(Arrays.asList(blastLocation + blastProg, "-outfmt", "6", "-query", queryArg, "-db", db, "-out", ou));
                                 blastCmd.addAll(BRIG.tokenizeOptions(blastOptions));
+                                int graphThreads = BlastSettings.getBlastThreads();
+                                if (graphThreads > 1 && (blastOptions == null || !blastOptions.contains("-num_threads"))) {
+                                    blastCmd.addAll(Arrays.asList("-num_threads", String.valueOf(graphThreads)));
+                                }
                                 error += BRIG.formatCommand(blastCmd) + "\n";
                                 Process q = BRIG.execCommand(blastCmd);
                                 String data;

--- a/src/brig/GraphFunctions.java
+++ b/src/brig/GraphFunctions.java
@@ -249,13 +249,11 @@ public static String parseBlast2Graph(int[] value, int[] repeats, String input, 
                             List<String> blastCmd = new ArrayList<>();
                             try {
                                 String queryArg;
-                                // Prefix with ring/sequence indices to avoid collision when two files
-                                // share the same name but live in different directories (issue #53)
                                 if (isGbk) {
-                                    ou = output + SL + "scratch" + SL + "r" + i + "s" + (j - 3) + "_" + BRIG.FetchFilename(queryFastaFile) + "Vs" + BRIG.FetchFilename(db) + ".tab";
+                                    ou = BRIG.blastOutputPath(output, i, j - 3, queryFastaFile, db);
                                     queryArg = queryFastaFile;
                                 } else {
-                                    ou = output + SL + "scratch" + SL + "r" + i + "s" + (j - 3) + "_" + BRIG.FetchFilename(queryFile) + "Vs" + BRIG.FetchFilename(db) + ".tab";
+                                    ou = BRIG.blastOutputPath(output, i, j - 3, queryFile, db);
                                     queryArg = queryFile;
                                 }
                                 if (System.getProperty("os.name").toLowerCase().indexOf("windows") == -1) {

--- a/src/brig/GraphFunctions.java
+++ b/src/brig/GraphFunctions.java
@@ -249,11 +249,13 @@ public static String parseBlast2Graph(int[] value, int[] repeats, String input, 
                             List<String> blastCmd = new ArrayList<>();
                             try {
                                 String queryArg;
+                                // Prefix with ring/sequence indices to avoid collision when two files
+                                // share the same name but live in different directories (issue #53)
                                 if (isGbk) {
-                                    ou = output + SL + "scratch" + SL +  BRIG.FetchFilename(queryFastaFile) + "Vs" + BRIG.FetchFilename(db) + ".tab";
+                                    ou = output + SL + "scratch" + SL + "r" + i + "s" + (j - 3) + "_" + BRIG.FetchFilename(queryFastaFile) + "Vs" + BRIG.FetchFilename(db) + ".tab";
                                     queryArg = queryFastaFile;
                                 } else {
-                                    ou = output + SL + "scratch" + SL + BRIG.FetchFilename(queryFile) + "Vs" + BRIG.FetchFilename(db) + ".tab";
+                                    ou = output + SL + "scratch" + SL + "r" + i + "s" + (j - 3) + "_" + BRIG.FetchFilename(queryFile) + "Vs" + BRIG.FetchFilename(db) + ".tab";
                                     queryArg = queryFile;
                                 }
                                 if (System.getProperty("os.name").toLowerCase().indexOf("windows") == -1) {

--- a/src/brig/One.java
+++ b/src/brig/One.java
@@ -400,9 +400,14 @@ private DefaultListModel refModel;
                 }
             }
             fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-            int result = fc.showOpenDialog(this);
+            fc.setDialogTitle("Select output folder");
+            int result = fc.showDialog(this, "Select");
             if (result == JFileChooser.APPROVE_OPTION && fc.getSelectedFile() != null) {
-                outputFolderField.setText(fc.getSelectedFile().toString());
+                File selected = fc.getSelectedFile();
+                if (!selected.exists()) {
+                    selected.mkdirs();
+                }
+                outputFolderField.setText(selected.toString());
             }
         } catch (Exception e) {
             log.error("Error in output browse button", e);
@@ -941,7 +946,11 @@ private DefaultListModel refModel;
 
     public void reload() {
         queryField.setText(BRIG.PROFILE.getRootElement().getAttributeValue("queryFile"));
-        blastOptionField.setText(BRIG.PROFILE.getRootElement().getAttributeValue("blastOptions"));
+        String opts = BRIG.PROFILE.getRootElement().getAttributeValue("blastOptions");
+        if (opts == null || opts.isEmpty()) {
+            opts = "-evalue 1e-5 -num_threads " + BlastSettings.getBlastThreads();
+        }
+        blastOptionField.setText(opts);
         outputFolderField.setText(BRIG.PROFILE.getRootElement().getAttributeValue("outputFolder"));
         String out = "";
         List<Element> oldRefs = BRIG.PROFILE.getRootElement().getChildren("refDir");

--- a/src/brig/SequenceUtils.java
+++ b/src/brig/SequenceUtils.java
@@ -144,6 +144,7 @@ public class SequenceUtils {
     @SuppressWarnings("unchecked")
     public static String FormatGenbank(String file, String header, String out, boolean embl, String pOption) throws FileNotFoundException, IOException {
         String error = "";
+        boolean hasSequence = false;
         try (var in = Files.newBufferedReader(Path.of(file));
              var out1 = Files.newBufferedWriter(Path.of(out + ".fna"))) {
             out1.write(">" + header);
@@ -153,14 +154,24 @@ public class SequenceUtils {
             int on = 0;
             while ((line = in.readLine()) != null) {
                 if (on == 1) {
-                    out1.write(line.replaceAll("[^a-zA-Z]+", ""));
-                    out1.newLine();
+                    String seq = line.replaceAll("[^a-zA-Z]+", "");
+                    if (!seq.isEmpty()) {
+                        hasSequence = true;
+                        out1.write(seq);
+                        out1.newLine();
+                    }
                 }
                 if ((line.startsWith("ORIGIN") && !embl)
                         || (embl && line.startsWith("SQ"))) {
                     on = 1;
                 }
             }
+        }
+        if (!hasSequence) {
+            String fmt = embl ? "EMBL" : "GenBank";
+            BRIG.Print("WARNING: " + fmt + " file '" + new java.io.File(file).getName()
+                    + "' contains no sequence data. Check the file has an ORIGIN/SQ section with sequence.");
+            error += "WARNING: No sequence data found in " + file + "\n";
         }
         if ("T".equals(pOption)) {
             try (var out2 = Files.newBufferedWriter(Path.of(out + ".faa"))) {

--- a/src/test/java/brig/BRIGCharacterizationTest.java
+++ b/src/test/java/brig/BRIGCharacterizationTest.java
@@ -149,8 +149,8 @@ class BRIGCharacterizationTest {
         assertEquals(">test_header", lines.get(0));
         // Regex strips all non-alpha chars (digits, spaces)
         assertEquals("atgcatgcatgcnnnatgcatgc", lines.get(1));
-        // "//" becomes empty string after stripping non-alpha
-        assertEquals("", lines.get(2));
+        // "//" becomes empty after stripping non-alpha and is now skipped
+        assertEquals(2, lines.size());
     }
 
     @Test
@@ -172,6 +172,44 @@ class BRIGCharacterizationTest {
         assertEquals(">embl_header", lines.get(0));
         // Strips digits and spaces from lines after the SQ trigger
         assertEquals("atgcatgcatgcnnnatgcatgc", lines.get(1));
+    }
+
+    // ---------------------------------------------------------------
+    // GenBank with no sequence data — regression for empty-sequence warning
+    // ---------------------------------------------------------------
+
+    @Test
+    void formatGenbank_noOrigin_warnsNoSequence(@TempDir Path tmp) throws Exception {
+        Path gbk = tmp.resolve("empty.gbk");
+        Files.writeString(gbk,
+                "LOCUS       EMPTY     0 bp\n"
+              + "DEFINITION  No sequence here\n"
+              + "//\n");
+
+        String outBase = tmp.resolve("out").toString();
+        String msg = BRIG.FormatGenbank(
+                gbk.toString(), "test_header", outBase, false, "F");
+
+        assertTrue(msg.contains("WARNING"), "Should warn about missing sequence data");
+        // The .fna file should exist but contain only the header
+        List<String> lines = Files.readAllLines(Path.of(outBase + ".fna"));
+        assertEquals(1, lines.size(), "Only header line expected when no sequence");
+        assertEquals(">test_header", lines.get(0));
+    }
+
+    @Test
+    void formatGenbank_emptyOrigin_warnsNoSequence(@TempDir Path tmp) throws Exception {
+        Path gbk = tmp.resolve("empty_origin.gbk");
+        Files.writeString(gbk,
+                "LOCUS       EMPTY     0 bp\n"
+              + "ORIGIN\n"
+              + "//\n");
+
+        String outBase = tmp.resolve("out").toString();
+        String msg = BRIG.FormatGenbank(
+                gbk.toString(), "test_header", outBase, false, "F");
+
+        assertTrue(msg.contains("WARNING"), "Should warn when ORIGIN section has no bases");
     }
 
     // ---------------------------------------------------------------

--- a/src/test/java/brig/BRIGStaticMethodsTest.java
+++ b/src/test/java/brig/BRIGStaticMethodsTest.java
@@ -285,6 +285,90 @@ class BRIGStaticMethodsTest {
     }
 
     // -------------------------------------------------------------------
+    // resolveGcWindow (issue #56 — configurable GC skew/content window)
+    // -------------------------------------------------------------------
+
+    @Test
+    void resolveGcWindow_noProfile_usesAutoScale() {
+        BRIG.GEN_LENGTH = 3_000_000;
+        BRIG.PROFILE = null;
+        // autoScale(3_000_000) = 3_000_000 / 3000 = 1000
+        assertEquals(1000, BRIG.resolveGcWindow());
+    }
+
+    @Test
+    void resolveGcWindow_withGcWindowSetting_returnsConfiguredValue() {
+        BRIG.GEN_LENGTH = 3_000_000;
+        Document doc = new Document(new Element("BRIG"));
+        Element brigSettings = new Element("brig_settings");
+        brigSettings.setAttribute("gcWindow", "500");
+        doc.getRootElement().addContent(brigSettings);
+        BRIG.PROFILE = doc;
+
+        assertEquals(500, BRIG.resolveGcWindow());
+    }
+
+    @Test
+    void resolveGcWindow_withInvalidGcWindowSetting_fallsBackToAutoScale() {
+        BRIG.GEN_LENGTH = 6_000_000;
+        Document doc = new Document(new Element("BRIG"));
+        Element brigSettings = new Element("brig_settings");
+        brigSettings.setAttribute("gcWindow", "not-a-number");
+        doc.getRootElement().addContent(brigSettings);
+        BRIG.PROFILE = doc;
+
+        // autoScale(6_000_000) = 2000
+        assertEquals(2000, BRIG.resolveGcWindow());
+    }
+
+    @Test
+    void resolveGcWindow_withZeroGcWindow_fallsBackToAutoScale() {
+        BRIG.GEN_LENGTH = 3_000_000;
+        Document doc = new Document(new Element("BRIG"));
+        Element brigSettings = new Element("brig_settings");
+        brigSettings.setAttribute("gcWindow", "0");
+        doc.getRootElement().addContent(brigSettings);
+        BRIG.PROFILE = doc;
+
+        assertEquals(1000, BRIG.resolveGcWindow());
+    }
+
+    // -------------------------------------------------------------------
+    // Same-filename BLAST output paths (issue #53)
+    // -------------------------------------------------------------------
+
+    @Test
+    void blastOutputPath_differentRingIndices_produceDistinctPaths() {
+        // Verify that the naming scheme ring{i}seq{j}_<filename> is distinct for
+        // two files with the same basename but at different ring positions.
+        String output = "/tmp/out";
+        String queryFastaFile = "/ref/reference.fna";
+        String fileA = "/folderA/genome.fna";
+        String fileB = "/folderB/genome.fna";
+
+        // Simulate the path formula used in RunBlast (ring 0 seq 0 vs ring 1 seq 0)
+        String ouA = output + "/scratch/r0s0_" + BRIG.FetchFilename(fileA) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
+        String ouB = output + "/scratch/r1s0_" + BRIG.FetchFilename(fileB) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
+
+        assertNotEquals(ouA, ouB,
+                "Two same-named files in different rings must produce distinct BLAST output paths");
+    }
+
+    @Test
+    void blastOutputPath_sameRingDifferentSeqIndices_produceDistinctPaths() {
+        String output = "/tmp/out";
+        String queryFastaFile = "/ref/reference.fna";
+        String fileA = "/folderA/genome.fna";
+        String fileB = "/folderB/genome.fna";
+
+        String ouA = output + "/scratch/r0s0_" + BRIG.FetchFilename(fileA) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
+        String ouB = output + "/scratch/r0s1_" + BRIG.FetchFilename(fileB) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
+
+        assertNotEquals(ouA, ouB,
+                "Two same-named files in different sequence slots must produce distinct BLAST output paths");
+    }
+
+    // -------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------
 

--- a/src/test/java/brig/BRIGStaticMethodsTest.java
+++ b/src/test/java/brig/BRIGStaticMethodsTest.java
@@ -140,17 +140,25 @@ class BRIGStaticMethodsTest {
 
     @Test
     void autoScale_smallSequence() {
-        assertEquals(16, BRIG.autoScale(50_000));
+        // 50_000 / 3000 = 16, clamped to minimum of 50
+        assertEquals(50, BRIG.autoScale(50_000));
     }
 
     @Test
     void autoScale_zeroLength() {
-        assertEquals(0, BRIG.autoScale(0));
+        assertEquals(50, BRIG.autoScale(0));
+    }
+
+    @Test
+    void autoScale_smallPlasmid() {
+        // 3000 / 3000 = 1, but minimum is 50
+        assertEquals(50, BRIG.autoScale(3000));
     }
 
     @Test
     void autoScale_exactMultiple() {
-        assertEquals(1, BRIG.autoScale(3000));
+        // 150000 / 3000 = 50 = minimum, so same result
+        assertEquals(50, BRIG.autoScale(150_000));
     }
 
     // -------------------------------------------------------------------
@@ -339,16 +347,13 @@ class BRIGStaticMethodsTest {
 
     @Test
     void blastOutputPath_differentRingIndices_produceDistinctPaths() {
-        // Verify that the naming scheme ring{i}seq{j}_<filename> is distinct for
-        // two files with the same basename but at different ring positions.
         String output = "/tmp/out";
         String queryFastaFile = "/ref/reference.fna";
         String fileA = "/folderA/genome.fna";
         String fileB = "/folderB/genome.fna";
 
-        // Simulate the path formula used in RunBlast (ring 0 seq 0 vs ring 1 seq 0)
-        String ouA = output + "/scratch/r0s0_" + BRIG.FetchFilename(fileA) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
-        String ouB = output + "/scratch/r1s0_" + BRIG.FetchFilename(fileB) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
+        String ouA = BRIG.blastOutputPath(output, 0, 0, fileA, queryFastaFile);
+        String ouB = BRIG.blastOutputPath(output, 1, 0, fileB, queryFastaFile);
 
         assertNotEquals(ouA, ouB,
                 "Two same-named files in different rings must produce distinct BLAST output paths");
@@ -361,11 +366,70 @@ class BRIGStaticMethodsTest {
         String fileA = "/folderA/genome.fna";
         String fileB = "/folderB/genome.fna";
 
-        String ouA = output + "/scratch/r0s0_" + BRIG.FetchFilename(fileA) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
-        String ouB = output + "/scratch/r0s1_" + BRIG.FetchFilename(fileB) + "Vs" + BRIG.FetchFilename(queryFastaFile) + ".tab";
+        String ouA = BRIG.blastOutputPath(output, 0, 0, fileA, queryFastaFile);
+        String ouB = BRIG.blastOutputPath(output, 0, 1, fileB, queryFastaFile);
 
         assertNotEquals(ouA, ouB,
                 "Two same-named files in different sequence slots must produce distinct BLAST output paths");
+    }
+
+    // -------------------------------------------------------------------
+    // blastOutputPath helper (extracted from RunBlast)
+    // -------------------------------------------------------------------
+
+    @Test
+    void blastOutputPath_containsRingAndSeqIndices() {
+        String path = BRIG.blastOutputPath("/out", 3, 7, "/dir/genome.fna", "/ref/ref.fna");
+        assertTrue(path.contains("r3s7_"), "Path must contain ring/seq prefix");
+        assertTrue(path.endsWith(".tab"), "Path must end with .tab");
+    }
+
+    @Test
+    void blastOutputPath_usesFilenamesNotFullPaths() {
+        String path = BRIG.blastOutputPath("/out", 0, 0, "/deep/dir/genome.fna", "/other/ref.fna");
+        assertFalse(path.contains("/deep/dir/"), "Path should not contain full directory of ring file");
+        assertTrue(path.contains("genome.fna"));
+        assertTrue(path.contains("ref.fna"));
+    }
+
+    // -------------------------------------------------------------------
+    // autoScale — minimum window for small sequences
+    // -------------------------------------------------------------------
+
+    @Test
+    void autoScale_plasmid3kb_returnsMinimum50() {
+        // 3000 bp plasmid: 3000/3000 = 1, clamped to 50
+        assertEquals(50, BRIG.autoScale(3000));
+    }
+
+    @Test
+    void autoScale_largeGenome_scalesNormally() {
+        // 5 Mbp: 5000000/3000 = 1666, well above minimum
+        assertEquals(1666, BRIG.autoScale(5_000_000));
+        assertTrue(BRIG.autoScale(5_000_000) > 50);
+    }
+
+    // -------------------------------------------------------------------
+    // Default BLAST threads — min(2, available)
+    // -------------------------------------------------------------------
+
+    @Test
+    void getBlastThreads_default_atMostTwo() {
+        BRIG.PROFILE = null;
+        int threads = BlastSettings.getBlastThreads();
+        assertTrue(threads >= 1 && threads <= 2,
+                "Default threads should be min(2, CPUs) but was " + threads);
+    }
+
+    @Test
+    void getBlastThreads_profileOverride_returnsConfiguredValue() {
+        Document doc = new Document(new Element("BRIG"));
+        Element settings = new Element("brig_settings");
+        settings.setAttribute("blastThreads", "8");
+        doc.getRootElement().addContent(settings);
+        BRIG.PROFILE = doc;
+
+        assertEquals(8, BlastSettings.getBlastThreads());
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Multithreaded BLAST** (closes #42): adds `-num_threads` to all BLAST calls; defaults to `min(2, CPUs)`; `--threads <n>` CLI override; `blastThreads` XML profile attribute; shown in default blast options field
- **Fix same-filename collision** (closes #53): extracted `blastOutputPath()` helper; BLAST output `.tab` files prefixed with `r{ring}s{seq}_` so files with the same name in different directories never overwrite each other
- **Configurable GC skew/content window** (closes #56): new `resolveGcWindow()` reads `gcWindow` from `brig_settings` XML; exposed as `--gc-window <n>` CLI option; falls back to auto-scale if not set
- **Smooth GC plots for small sequences**: sliding window with overlap for CGContent/CGskew; `autoScale` minimum of 50 bp; `gcStep()` targets ~3000 segments; last segment extends to end of sequence
- **Default blast options**: `-evalue 1e-5 -num_threads <n>` shown in GUI blast options field by default
- **Output folder browser**: uses `showDialog` with `mkdirs()` so users can create and select new folders
- **Graph ring bounds check**: skips graph entries exceeding reference length with a warning
- **GenBank/EMBL empty-sequence warning**: warns when input file has no sequence data
- **Fix CustomXML browse NPE**: null-safe file chooser when genbank file field is empty
- **Version bump to 1.1.0**: pom.xml, pixi.toml, About dialog (now reads from manifest)
- **Auto-release workflow hardened**: env vars instead of inline interpolation; `[no ci]` commit message
- **Bump actions**: upload-artifact v7, download-artifact v8, maven-shade-plugin 3.6.2
- **CI**: pixi + BLAST+ for E2E tests
- **CHANGELOG.md**: added v1.1.0 entry

## Changes

| File | What changed |
|------|-------------|
| `BRIG.java` | Sliding window GC content/skew; `blastOutputPath()` helper; `gcStep()`; `autoScale` min 50; graph bounds check; BLAST threads log fix |
| `BRIGcli.java` | `--gc-window <n>` and `--threads <n>` args |
| `BlastSettings.java` | Default threads `min(2, CPUs)` |
| `GraphFunctions.java` | Uses `blastOutputPath()` helper; adds `-num_threads` |
| `Graph.java` | Default blast options; null-safe blast opts; output folder create |
| `One.java` | Default blast options with evalue/threads; output folder create |
| `About.java` / `About.form` | Version from manifest instead of hardcoded |
| `CustomXML.java` | Null-safe file chooser |
| `SequenceUtils.java` | Warn on empty GenBank/EMBL sequence |
| `pom.xml` / `pixi.toml` | Version 1.1.0 |
| `CHANGELOG.md` | New: v1.1.0 release notes |
| `auto-release.yml` | Hardened shell variable handling |
| `ci.yml` | Pixi + E2E tests |
| `release.yml` | Bump artifact actions |
| `BRIGStaticMethodsTest.java` | Tests for blastOutputPath, autoScale, default threads |
| `BRIGCharacterizationTest.java` | Tests for empty GenBank warning |

## Test plan
- [x] All 145 tests pass (`mvn test`)
- [x] New regression tests: blastOutputPath (2), autoScale (2), default threads (2), empty GenBank (2)
- [x] Manual: smooth GC content/skew on 3kb plasmid (pOSAK1)
- [x] Manual: output folder create-and-select works
- [x] Manual: graph ring with out-of-bounds coords skipped with warning
- [ ] Manual: verify auto-release bumps version on next PR merge

Closes #42
Closes #53
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)