### PR TITLE
Fix auto-release: tag-only to avoid branch protection block

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -16,17 +16,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Get current version
         id: current_version
@@ -40,7 +34,6 @@ jobs:
         env:
           CURRENT: ${{ steps.current_version.outputs.version }}
         run: |
-          # Split on dots and bump patch
           MAJOR=$(echo "$CURRENT" | cut -d. -f1)
           MINOR=$(echo "$CURRENT" | cut -d. -f2)
           PATCH=$(echo "$CURRENT" | cut -d. -f3)
@@ -49,26 +42,11 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
-      - name: Set new version in pom.xml and pixi.toml
-        env:
-          NEW_VERSION: ${{ steps.new_version.outputs.version }}
-        run: |
-          mvn versions:set -DnewVersion="$NEW_VERSION" -DgenerateBackupPoms=false -q
-          sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pixi.toml
-
-      - name: Commit version bump
-        env:
-          NEW_VERSION: ${{ steps.new_version.outputs.version }}
-        run: |
-          git add pom.xml pixi.toml
-          git commit -m "chore: bump version to ${NEW_VERSION} [no ci]"
-
       - name: Create and push tag
         env:
           NEW_VERSION: ${{ steps.new_version.outputs.version }}
         run: |
           TAG="v${NEW_VERSION}"
           git tag "$TAG"
-          git push origin master
           git push origin "$TAG"
           echo "Created tag $TAG — release workflow will build packages"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/happykhan/BRIG/actions/workflows/ci.yml/badge.svg)](https://github.com/happykhan/BRIG/actions/workflows/ci.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![GitHub release](https://img.shields.io/github/v/release/happykhan/BRIG)](https://github.com/happykhan/BRIG/releases/latest)
+![SourceForge Downloads](https://img.shields.io/sourceforge/dm/brig)
+![SourceForge Downloads](https://img.shields.io/sourceforge/dt/brig)
 
 BRIG is a cross-platform (Windows/Mac/Linux) application that displays circular comparison images of multiple genomes using BLAST. It is designed to handle genome assembly data and can show similarity, coverage, annotations and more as concentric rings around a reference sequence.
 


### PR DESCRIPTION
## Summary

- Auto-release workflow was failing because `git push origin master` is blocked by branch protection requiring status checks
- Simplified to just create and push a tag from the merge commit — no commit to master needed
- The tag triggers the existing `release.yml` to build DMG/MSI/JAR packages

## Test plan
- [x] Verified previous failure: `Protected branch update failed for refs/heads/master`
- [ ] Merge this PR and verify tag `v1.1.1` is created and release workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)