### PR TITLE
Fix auto-release: explicitly trigger release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v6
@@ -49,4 +50,9 @@ jobs:
           TAG="v${NEW_VERSION}"
           git tag "$TAG"
           git push origin "$TAG"
-          echo "Created tag $TAG — release workflow will build packages"
+          echo "Created tag $TAG"
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release.yml --ref "v${NEW_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build-jar:


### PR DESCRIPTION
## Summary

- Tags pushed by `GITHUB_TOKEN` don't trigger other workflows (GitHub security limitation)
- Added `workflow_dispatch` trigger to `release.yml` so it can be called manually or programmatically
- Auto-release now explicitly calls `gh workflow run release.yml` after pushing the tag

## Test plan
- [ ] Merge this PR → auto-release creates tag → release workflow builds packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)