### PR TITLE
Fix auto-release: pass version to trigger step

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -55,4 +55,5 @@ jobs:
       - name: Trigger release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.new_version.outputs.version }}
         run: gh workflow run release.yml --ref "v${NEW_VERSION}"


### PR DESCRIPTION
## Summary

One-line fix: the 'Trigger release workflow' step was missing `NEW_VERSION` in its `env` block, so `gh workflow run --ref "v${NEW_VERSION}"` resolved to `--ref "v"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)